### PR TITLE
Issue13 file path convert

### DIFF
--- a/adapter/comm/tools.py
+++ b/adapter/comm/tools.py
@@ -38,8 +38,7 @@ def convert_path(win_path: str) -> str:
     elif sys.platform == 'linux':
         mount_point = '/media/forecast'
     else:
-        logging.ERROR('Not supported OS!')
-        raise IOError()
+        raise IOError(f'Not supported OS: {sys.platform}!')
     parts = win_path.split('\\')
     parts[0] = mount_point
     logging.debug(parts)

--- a/adapter/comm/tools.py
+++ b/adapter/comm/tools.py
@@ -1,4 +1,33 @@
-import sys, re, os
+import logging
+import re
+import sys
+
+
+def convert_path(win_path: str) -> str:
+    """
+        Convert Windows input path according to current OS. IOError will raise if current OS is un-supported.
+
+    Args:
+        win_path: Windows format path str
+
+    Returns:
+        cur_path: Current system format path str
+    """
+    if sys.platform == 'win32':
+        return win_path
+    elif sys.platform == 'darwin':
+        mount_point = '/Volumes/ees'
+    elif sys.platform == 'linux':
+        mount_point = '/media/forecast'
+    else:
+        logging.ERROR('Not supported OS!')
+        raise IOError()
+    parts = win_path.split('\\')
+    parts[0] = mount_point
+    logging.debug(parts)
+    cur_path = '/'.join(parts)
+    logging.debug(cur_path)
+    return cur_path
 
 
 def process_column_labels(list_of_labels):
@@ -23,10 +52,11 @@ def process_column_labels(list_of_labels):
 
 
 def convert_network_drive_path(
-    str_or_path, mapping=[("X:", "/Volumes/my_drive")]
+        str_or_path, mapping=[("X:", "/Volumes/my_drive")]
 ):
     """
-    Convert network drive paths from those formatted for one OS into those formatted for another. (works for Windows <-> OSX)
+    Convert network drive paths from those formatted for one OS into those formatted for another. (works for Windows
+    <-> OSX)
     If a string that doesn't seem to represent a path in the other OS is given, it will be returned unchanged.
 
     Parameters:
@@ -34,7 +64,9 @@ def convert_network_drive_path(
             string holding a filepath.
 
         mapping: list
-            list of 2-tuples where 0th entry of each tuple is the name of a windows network drive location (e.g. "A:") and the 1st entry is OSX network drive location (e.g. "/Volumes/A"). Defaults to [("X:","/Volumes/my_folder")].
+            list of 2-tuples where 0th entry of each tuple is the name of a windows network drive location (e.g.
+            "A:") and the 1st entry is OSX network drive location (e.g. "/Volumes/A"). Defaults to [("X:",
+            "/Volumes/my_folder")].
 
     Returns:
         str_or_path: str
@@ -110,7 +142,7 @@ def user_select_file(user_message="", mul_fls=False):
         fd.SetOFNTitle(user_message)
         if fd.DoModal() == win32con.IDCANCEL:
             sys.exit(1)
-    
+
         # file_name = fd.GetFileName()
         fpath = fd.GetPathName()
 
@@ -130,8 +162,7 @@ def user_select_file(user_message="", mul_fls=False):
 
         else:
             fpath = fd.askopenfilename(
-                title=user_message, filetypes=[("Excel", "*.xlsx *.xls"),("Database", "*.db")]
+                title=user_message, filetypes=[("Excel", "*.xlsx *.xls"), ("Database", "*.db")]
             )
 
         return fpath
-

--- a/adapter/comm/tools.py
+++ b/adapter/comm/tools.py
@@ -12,6 +12,24 @@ def convert_path(win_path: str) -> str:
 
     Returns:
         cur_path: Current system format path str
+    Notes:
+        ┍━━━━━━━━━━━━━━━━━━━━━┯━━━━━━━━━━━━━━━━━━━━━┑
+        │ System              │ Value               │
+        ┝━━━━━━━━━━━━━━━━━━━━━┿━━━━━━━━━━━━━━━━━━━━━┥
+        │ Linux               │ linux or linux2 (*) │
+        │ Windows             │ win32               │
+        │ Windows/Cygwin      │ cygwin              │
+        │ Windows/MSYS2       │ msys                │
+        │ Mac OS X            │ darwin              │
+        │ OS/2                │ os2                 │
+        │ OS/2 EMX            │ os2emx              │
+        │ RiscOS              │ riscos              │
+        │ AtheOS              │ atheos              │
+        │ FreeBSD 7           │ freebsd7            │
+        │ FreeBSD 8           │ freebsd8            │
+        │ FreeBSD N           │ freebsdN            │
+        │ OpenBSD 6           │ openbsd6            │
+        ┕━━━━━━━━━━━━━━━━━━━━━┷━━━━━━━━━━━━━━━━━━━━━┙
     """
     if sys.platform == 'win32':
         return win_path

--- a/adapter/tests/test_tools.py
+++ b/adapter/tests/test_tools.py
@@ -1,0 +1,23 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from adapter.comm.tools import convert_path
+
+
+class Test(TestCase):
+    def setUp(self) -> None:
+        self.win_dir = "a:\\b\\c\\d\\e\\f.gh"
+        self.linux = "/media/forecast/b/c/d/e/f.gh"
+        self.osx = "/Volumes/ees/b/c/d/e/f.gh"
+
+    @patch('sys.platform', 'linux')
+    def test_linux(self):
+        self.assertEqual(self.linux, convert_path(self.win_dir))
+
+    @patch('sys.platform', 'darwin')
+    def test_osx(self):
+        self.assertEqual(self.osx, convert_path(self.win_dir))
+
+    @patch('sys.platform', 'win32')
+    def test_win(self):
+        self.assertEqual(self.win_dir, convert_path(self.win_dir))

--- a/adapter/tests/test_tools.py
+++ b/adapter/tests/test_tools.py
@@ -10,6 +10,11 @@ class Test(TestCase):
         self.linux = "/media/forecast/b/c/d/e/f.gh"
         self.osx = "/Volumes/ees/b/c/d/e/f.gh"
 
+    def tearDown(self) -> None:
+        del self.win_dir
+        del self.linux
+        del self.osx
+
     @patch('sys.platform', 'freebsd7')
     def test_unix(self):
         with self.assertRaises(IOError):

--- a/adapter/tests/test_tools.py
+++ b/adapter/tests/test_tools.py
@@ -10,6 +10,11 @@ class Test(TestCase):
         self.linux = "/media/forecast/b/c/d/e/f.gh"
         self.osx = "/Volumes/ees/b/c/d/e/f.gh"
 
+    @patch('sys.platform', 'freebsd7')
+    def test_unix(self):
+        with self.assertRaises(IOError):
+            convert_path(self.win_dir)
+
     @patch('sys.platform', 'linux')
     def test_linux(self):
         self.assertEqual(self.linux, convert_path(self.win_dir))


### PR DESCRIPTION
introduced a common method to convert windows path format to users' local system path format.
`W:\Cross-cutting APS\Programming\Test Files\Tester\ref_results\lcc` will convert to `/Volumn/ees/Cross-cutting APS/Programming/Test Files/Tester/ref_results/lcc` on Mac OSX