### PR TITLE
Updated to_python.Db to check duplicates for table_names.

### DIFF
--- a/adapter/__init__.py
+++ b/adapter/__init__.py
@@ -5,4 +5,4 @@
 
 # build dist backup: drive, Public Code/Adapter
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/adapter/tests/test_to_python.py
+++ b/adapter/tests/test_to_python.py
@@ -101,6 +101,10 @@ class TestDb(TestCase):
         # test file load with pre_existing_keys
         with self.assertRaises(ValueError):
             self.db.load()
+        # test file load with table names and pre_expisting keys
+        self.assertEqual(set(self.db.load(table_names=['table2']).keys()), {'table2'})
+        with self.assertRaises(ValueError):
+            self.db.load(table_names=['table1'])
 
     def test_load_bad_db(self):
         # test corrupt file load

--- a/adapter/to_python.py
+++ b/adapter/to_python.py
@@ -281,8 +281,10 @@ class Db(object):
             raise IOError(
                 f'0 table found in the database file! The input file: {self.file_path} may be unsupported or corrupted')
         if self.pre_existing_keys is not None:
+            # check for duplicates in tables_names,
+            # if table_names == None, check for duplcates for all the tables
             Debugger.check_for_duplicates(
-                self.pre_existing_keys, keys
+                self.pre_existing_keys, table_names or keys
             )
             # skip pre_existing_keys
         if table_names is not None:


### PR DESCRIPTION
1. Updated `to_python.Db` to check duplicates for `table_names`
2. Updates `test_to_python.TestDb` accordingly.
3. Updated version number to v1.3.1