### PR TITLE
Issue13 file path convert

### DIFF
--- a/adapter/__init__.py
+++ b/adapter/__init__.py
@@ -5,4 +5,4 @@
 
 # build dist backup: drive, Public Code/Adapter
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"

--- a/adapter/comm/tests/test_tools.py
+++ b/adapter/comm/tests/test_tools.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from unittest.mock import patch
 
-from adapter.comm.tools import convert_network_drive_path
+from adapter.comm.tools import convert_network_drive_path, get_mount_point_len
 
 
 class Test(TestCase):
@@ -13,6 +13,42 @@ class Test(TestCase):
         self.assertEqual(convert_network_drive_path(str_or_path), '/Volumes/A/xyz/c/d/1.xlsx')
         str_or_path = r'X:\abc\def\hij\1.xlsx'
         self.assertEqual(convert_network_drive_path(str_or_path), '/Volumes/A/abc/def/hij/1.xlsx')
+        # test backwards compatibility
+        str_or_path = '/Volumes/A/abc/c/d/1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path, mapping=[('X:', '/Volumes/A')]),
+                         '/Volumes/A/abc/c/d/1.xlsx')
+        str_or_path = r'X:\abc\def\hij\1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path, mapping=[('X:', '/Volumes/A')]),
+                         '/Volumes/A/abc/def/hij/1.xlsx')
+        path_a = r"A:\some_folder\some_file.txt"
+        path_b = '/Volumes/A/some_folder/some_file.txt'
+        self.assertEqual(
+            convert_network_drive_path(path_a, mapping=[('A:', '/Volumes/A')]), path_b)
+        # test convert_network_drive_path empty
+        p = {}
+        self.assertEqual(convert_network_drive_path(str_or_path=p
+                                                    ), p)
+
+        # test convert_network_drive_path relative
+        str_or_path = r'abc\def\hij\1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
+        str_or_path = 'output/file.txt'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
+
+        # test convert_network_drive_path local_nonexists
+        str_or_path = r"C:\some_folder\some_file.xlsx"
+        expected_path = '/Volumes/A/some_folder/some_file.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path), expected_path)
+
+        # test convert_network_drive_path exists
+        str_or_path = r'Adapter\adapter\tests\corrupt.db'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
+        str_or_path = r'test_done.db'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
+        str_or_path = 'input/input_folder'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
+        str_or_path = r'output\output_folder'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
 
     @patch('sys.platform', 'win32')
     def test_convert_network_drive_path_win(self):
@@ -22,6 +58,41 @@ class Test(TestCase):
         self.assertEqual(convert_network_drive_path(str_or_path), r'X:xyz\c\d\1.xlsx')
         str_or_path = r'X:\abc\def\hij\1.xlsx'
         self.assertEqual(convert_network_drive_path(str_or_path), r'X:\abc\def\hij\1.xlsx')
+        str_or_path = '/Volumes/A/abc/c/d/1.xlsx'
+        # test backwards compatibility
+        self.assertEqual(convert_network_drive_path(str_or_path, mapping=[('X:', '/Volumes/A')]), r'X:abc\c\d\1.xlsx')
+        str_or_path = r'X:\abc\def\hij\1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path, mapping=[('X:', '/Volumes/A')]),
+                         r'X:\abc\def\hij\1.xlsx')
+        path_a = r'A:some_folder\some_file.txt'
+        path_b = '/Volumes/A/some_folder/some_file.txt'
+        self.assertEqual(
+            convert_network_drive_path(path_b, mapping=[('A:', '/Volumes/A')]), path_a)
+        # test convert_network_drive_path empty
+        p = {}
+        self.assertEqual(convert_network_drive_path(str_or_path=p
+                                                    ), p)
+
+        # test convert_network_drive_path relative
+        str_or_path = r'abc\def\hij\1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
+        str_or_path = 'output/file.txt'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
+
+        # test convert_network_drive_path local_nonexists
+        str_or_path = r"C:\some_folder\some_file.xlsx"
+        expected_path = r"X:some_folder\some_file.xlsx"
+        self.assertEqual(convert_network_drive_path(str_or_path), expected_path)
+
+        # test convert_network_drive_path exists
+        str_or_path = r'Adapter\adapter\tests\corrupt.db'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
+        str_or_path = r'test_done.db'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
+        str_or_path = 'input/input_folder'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
+        str_or_path = r'output\output_folder'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
 
     @patch('sys.platform', 'linux')
     def test_convert_network_drive_path_lin(self):
@@ -31,41 +102,25 @@ class Test(TestCase):
         self.assertEqual(convert_network_drive_path(str_or_path), '/media/b/xyz/c/d/1.xlsx')
         str_or_path = r'X:\abc\def\hij\1.xlsx'
         self.assertEqual(convert_network_drive_path(str_or_path), '/media/b/abc/def/hij/1.xlsx')
+        # test backwards compatibility this should not even happen since it was not supported
 
-    @patch('sys.platform', 'darwin')
-    def test_backward_convert_network_drive_path_mac(self):
-        str_or_path = '/Volumes/A/abc/c/d/1.xlsx'
-        self.assertEqual(convert_network_drive_path(str_or_path, mapping=[('X:', '/Volumes/A')]),
-                         '/Volumes/A/abc/c/d/1.xlsx')
-        str_or_path = r'X:\abc\def\hij\1.xlsx'
-        self.assertEqual(convert_network_drive_path(str_or_path, mapping=[('X:', '/Volumes/A')]),
-                         '/Volumes/A/abc/def/hij/1.xlsx')
-
-    @patch('sys.platform', 'win32')
-    def test_backward_convert_network_drive_path_win(self):
-        str_or_path = '/Volumes/A/abc/c/d/1.xlsx'
-        self.assertEqual(convert_network_drive_path(str_or_path, mapping=[('X:', '/Volumes/A')]), r'X:abc\c\d\1.xlsx')
-        str_or_path = r'X:\abc\def\hij\1.xlsx'
-        self.assertEqual(convert_network_drive_path(str_or_path, mapping=[('X:', '/Volumes/A')]),
-                         r'X:\abc\def\hij\1.xlsx')
-
-    def test_convert_network_drive_path_empty(self):
+        # test convert_network_drive_path empty
         p = {}
         self.assertEqual(convert_network_drive_path(str_or_path=p
                                                     ), p)
 
-    def test_convert_network_drive_path_relative(self):
+        # test convert_network_drive_path relative
         str_or_path = r'abc\def\hij\1.xlsx'
         self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
         str_or_path = 'output/file.txt'
         self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
 
-    def test_convert_network_drive_path_local_nonexists(self):
+        # test convert_network_drive_path local_nonexists
         str_or_path = r"C:\some_folder\some_file.xlsx"
-        expected_path = r"X:\some_folder\some_file.xlsx"
+        expected_path = '/media/b/some_folder/some_file.xlsx'
         self.assertEqual(convert_network_drive_path(str_or_path), expected_path)
 
-    def test_convert_network_drive_path_exists(self):
+        # test convert_network_drive_path exists
         str_or_path = r'Adapter\adapter\tests\corrupt.db'
         self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
         str_or_path = r'test_done.db'
@@ -74,3 +129,9 @@ class Test(TestCase):
         self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
         str_or_path = r'output\output_folder'
         self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
+
+    def test_get_mount_point_len(self):
+        self.assertEqual(get_mount_point_len(mapping={'win32': 'X:', 'darwin': '/Volumes/A', 'linux': '/media/b'},
+                                             str_or_path=r'X:\Abc\1.txt'), 2)
+        self.assertEqual(get_mount_point_len(mapping={'win32': 'X:', 'darwin': '/Volumes/A', 'linux': '/media/b'},
+                                             str_or_path='/Volumes/A/abc/c/d/1.xlsx'), 10)

--- a/adapter/comm/tests/test_tools.py
+++ b/adapter/comm/tests/test_tools.py
@@ -60,6 +60,11 @@ class Test(TestCase):
         str_or_path = 'output/file.txt'
         self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
 
+    def test_convert_network_drive_path_local_nonexists(self):
+        str_or_path = r"C:\some_folder\some_file.xlsx"
+        expected_path = r"X:\some_folder\some_file.xlsx"
+        self.assertEqual(convert_network_drive_path(str_or_path), expected_path)
+
     def test_convert_network_drive_path_exists(self):
         str_or_path = r'Adapter\adapter\tests\corrupt.db'
         self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)

--- a/adapter/comm/tests/test_tools.py
+++ b/adapter/comm/tests/test_tools.py
@@ -7,27 +7,27 @@ from adapter.comm.tools import convert_network_drive_path
 class Test(TestCase):
     @patch('sys.platform', 'darwin')
     def test_convert_network_drive_path_mac(self):
-        str_or_path = '//Volumes/ees/abc/c/d/1.xlsx'
+        str_or_path = '/Volumes/A/abc/c/d/1.xlsx'
         self.assertEqual(convert_network_drive_path(str_or_path), '/Volumes/A/abc/c/d/1.xlsx')
-        str_or_path = '//media/ees/xyz/c/d/1.xlsx'
+        str_or_path = '/media/b/xyz/c/d/1.xlsx'
         self.assertEqual(convert_network_drive_path(str_or_path), '/Volumes/A/xyz/c/d/1.xlsx')
         str_or_path = r'X:\abc\def\hij\1.xlsx'
         self.assertEqual(convert_network_drive_path(str_or_path), '/Volumes/A/abc/def/hij/1.xlsx')
 
     @patch('sys.platform', 'win32')
     def test_convert_network_drive_path_win(self):
-        str_or_path = '//Volumes/ees/abc/c/d/1.xlsx'
+        str_or_path = '/Volumes/A/abc/c/d/1.xlsx'
         self.assertEqual(convert_network_drive_path(str_or_path), r'X:abc\c\d\1.xlsx')
-        str_or_path = '//media/ees/xyz/c/d/1.xlsx'
+        str_or_path = '/media/b/xyz/c/d/1.xlsx'
         self.assertEqual(convert_network_drive_path(str_or_path), r'X:xyz\c\d\1.xlsx')
         str_or_path = r'X:\abc\def\hij\1.xlsx'
         self.assertEqual(convert_network_drive_path(str_or_path), r'X:\abc\def\hij\1.xlsx')
 
     @patch('sys.platform', 'linux')
     def test_convert_network_drive_path_lin(self):
-        str_or_path = '//Volumes/ees/abc/c/d/1.xlsx'
+        str_or_path = '/Volumes/A/abc/c/d/1.xlsx'
         self.assertEqual(convert_network_drive_path(str_or_path), '/media/b/abc/c/d/1.xlsx')
-        str_or_path = '//media/ees/xyz/c/d/1.xlsx'
+        str_or_path = '/media/b/xyz/c/d/1.xlsx'
         self.assertEqual(convert_network_drive_path(str_or_path), '/media/b/xyz/c/d/1.xlsx')
         str_or_path = r'X:\abc\def\hij\1.xlsx'
         self.assertEqual(convert_network_drive_path(str_or_path), '/media/b/abc/def/hij/1.xlsx')

--- a/adapter/comm/tests/test_tools.py
+++ b/adapter/comm/tests/test_tools.py
@@ -35,18 +35,18 @@ class Test(TestCase):
     @patch('sys.platform', 'darwin')
     def test_backward_convert_network_drive_path_mac(self):
         str_or_path = '/Volumes/A/abc/c/d/1.xlsx'
-        self.assertEqual(convert_network_drive_path(str_or_path, mapping=['X:', '/Volumes/A']),
+        self.assertEqual(convert_network_drive_path(str_or_path, mapping=[('X:', '/Volumes/A')]),
                          '/Volumes/A/abc/c/d/1.xlsx')
         str_or_path = r'X:\abc\def\hij\1.xlsx'
-        self.assertEqual(convert_network_drive_path(str_or_path, mapping=['X:', '/Volumes/A']),
+        self.assertEqual(convert_network_drive_path(str_or_path, mapping=[('X:', '/Volumes/A')]),
                          '/Volumes/A/abc/def/hij/1.xlsx')
 
     @patch('sys.platform', 'win32')
     def test_backward_convert_network_drive_path_win(self):
         str_or_path = '/Volumes/A/abc/c/d/1.xlsx'
-        self.assertEqual(convert_network_drive_path(str_or_path, mapping=['X:', '/Volumes/A']), r'X:abc\c\d\1.xlsx')
+        self.assertEqual(convert_network_drive_path(str_or_path, mapping=[('X:', '/Volumes/A')]), r'X:abc\c\d\1.xlsx')
         str_or_path = r'X:\abc\def\hij\1.xlsx'
-        self.assertEqual(convert_network_drive_path(str_or_path, mapping=['X:', '/Volumes/A']),
+        self.assertEqual(convert_network_drive_path(str_or_path, mapping=[('X:', '/Volumes/A')]),
                          r'X:\abc\def\hij\1.xlsx')
 
     def test_convert_network_drive_path_empty(self):

--- a/adapter/comm/tests/test_tools.py
+++ b/adapter/comm/tests/test_tools.py
@@ -42,3 +42,9 @@ class Test(TestCase):
         self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
         str_or_path = 'output/file.txt'
         self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
+
+    def test_convert_network_drive_path_exists(self):
+        str_or_path = r'..\..\..\Adapter\adapter\tests\corrupt.db'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
+        str_or_path = r'test_done.db'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)

--- a/adapter/comm/tests/test_tools.py
+++ b/adapter/comm/tests/test_tools.py
@@ -1,0 +1,44 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from adapter.comm.tools import convert_network_drive_path
+
+
+class Test(TestCase):
+    @patch('sys.platform', 'darwin')
+    def test_convert_network_drive_path_mac(self):
+        str_or_path = '//Volumes/ees/abc/c/d/1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path), '/Volumes/A/abc/c/d/1.xlsx')
+        str_or_path = '//media/ees/xyz/c/d/1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path), '/Volumes/A/xyz/c/d/1.xlsx')
+        str_or_path = r'X:\abc\def\hij\1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path), '/Volumes/A/abc/def/hij/1.xlsx')
+
+    @patch('sys.platform', 'win32')
+    def test_convert_network_drive_path_win(self):
+        str_or_path = '//Volumes/ees/abc/c/d/1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path), r'X:abc\c\d\1.xlsx')
+        str_or_path = '//media/ees/xyz/c/d/1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path), r'X:xyz\c\d\1.xlsx')
+        str_or_path = r'X:\abc\def\hij\1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path), r'X:\abc\def\hij\1.xlsx')
+
+    @patch('sys.platform', 'linux')
+    def test_convert_network_drive_path_lin(self):
+        str_or_path = '//Volumes/ees/abc/c/d/1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path), '/media/b/abc/c/d/1.xlsx')
+        str_or_path = '//media/ees/xyz/c/d/1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path), '/media/b/xyz/c/d/1.xlsx')
+        str_or_path = r'X:\abc\def\hij\1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path), '/media/b/abc/def/hij/1.xlsx')
+
+    def test_convert_network_drive_path_empty(self):
+        p = {}
+        self.assertEqual(convert_network_drive_path(str_or_path=p
+                                                    ), p)
+
+    def test_convert_network_drive_path_relative(self):
+        str_or_path = r'abc\def\hij\1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
+        str_or_path = 'output/file.txt'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)

--- a/adapter/comm/tests/test_tools.py
+++ b/adapter/comm/tests/test_tools.py
@@ -32,6 +32,23 @@ class Test(TestCase):
         str_or_path = r'X:\abc\def\hij\1.xlsx'
         self.assertEqual(convert_network_drive_path(str_or_path), '/media/b/abc/def/hij/1.xlsx')
 
+    @patch('sys.platform', 'darwin')
+    def test_backward_convert_network_drive_path_mac(self):
+        str_or_path = '/Volumes/A/abc/c/d/1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path, mapping=['X:', '/Volumes/A']),
+                         '/Volumes/A/abc/c/d/1.xlsx')
+        str_or_path = r'X:\abc\def\hij\1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path, mapping=['X:', '/Volumes/A']),
+                         '/Volumes/A/abc/def/hij/1.xlsx')
+
+    @patch('sys.platform', 'win32')
+    def test_backward_convert_network_drive_path_win(self):
+        str_or_path = '/Volumes/A/abc/c/d/1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path, mapping=['X:', '/Volumes/A']), r'X:abc\c\d\1.xlsx')
+        str_or_path = r'X:\abc\def\hij\1.xlsx'
+        self.assertEqual(convert_network_drive_path(str_or_path, mapping=['X:', '/Volumes/A']),
+                         r'X:\abc\def\hij\1.xlsx')
+
     def test_convert_network_drive_path_empty(self):
         p = {}
         self.assertEqual(convert_network_drive_path(str_or_path=p
@@ -44,7 +61,11 @@ class Test(TestCase):
         self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
 
     def test_convert_network_drive_path_exists(self):
-        str_or_path = r'..\..\..\Adapter\adapter\tests\corrupt.db'
+        str_or_path = r'Adapter\adapter\tests\corrupt.db'
         self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
         str_or_path = r'test_done.db'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
+        str_or_path = 'input/input_folder'
+        self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)
+        str_or_path = r'output\output_folder'
         self.assertEqual(convert_network_drive_path(str_or_path), str_or_path)

--- a/adapter/comm/tools.py
+++ b/adapter/comm/tools.py
@@ -1,7 +1,7 @@
 import os
 import re
 import sys
-from pathlib import PurePath, PureWindowsPath, PurePosixPath
+from pathlib import PureWindowsPath, PurePosixPath
 
 
 def process_column_labels(list_of_labels):
@@ -73,7 +73,7 @@ def convert_network_drive_path(
         return str_or_path
     if ":" in str_or_path:
         # create win path
-        file_path = PureWindowsPath(str_or_path[get_mount_point_len(mapping, str_or_path) + 1:])
+        file_path = PureWindowsPath(str_or_path[str_or_path.index(':') + 1:])
     else:
         file_path = PurePosixPath(str_or_path[get_mount_point_len(mapping, str_or_path) + 1:])
     if sys.platform == "win32":

--- a/adapter/comm/tools.py
+++ b/adapter/comm/tools.py
@@ -87,6 +87,10 @@ def convert_network_drive_path(
 
 def get_mount_point_len(mapping: dict, str_or_path: str) -> int:
     """Get the length of the current mount point.
+    For example, get_mount_point_len(mapping={'win32': 'X:',
+    'darwin': '/Volumes/A', 'linux': '/media/b'}, str_or_path=r'X:\Abc\1.txt') => 2.
+    get_mount_point_len(mapping={'win32': 'X:',
+    'darwin': '/Volumes/A', 'linux': '/media/b'}, str_or_path='/Volumes/A/1.txt') => 10
 
     Parameters:
         mapping: dict
@@ -95,13 +99,12 @@ def get_mount_point_len(mapping: dict, str_or_path: str) -> int:
             A path str. For example, 'X:\Abc\1.txt'
 
     Returns:
-            the length of the mount point
+            the length of the mount point, or 0 when no match found
     """
-    mp = 0
     for v in mapping.values():
         if v.upper() == (str_or_path[: len(v)]).upper():
             return len(v)
-    return mp
+    return 0
 
 
 def user_select_file(user_message="", mul_fls=False):

--- a/adapter/comm/tools.py
+++ b/adapter/comm/tools.py
@@ -49,18 +49,24 @@ def convert_network_drive_path(
     Raises:
         Exception: When no mapping is given or running on an unsupported OS
     """
-    if (
-        (not isinstance(str_or_path, str))
-        or os.path.isfile(str_or_path)
-        or (not (str_or_path[0] == "/" or ":" in str_or_path))
-    ):
-        # return if abs file exists or path is absolute, return if it's relative.
+    # backwards compatibility
+    if not isinstance(mapping, dict):
+        # automatically assume list of tuples
+        os_mapping = {
+            'win32': mapping[0],
+            'darwin': mapping[1],
+        }
+        mapping = os_mapping
+    if not isinstance(str_or_path, str):
+        return str_or_path
+    if not (str_or_path[0] == "/" or ":" in str_or_path):
+        # return if it's relative.
         # Note: either os.path nor pathlib work correctly
         return str_or_path
-    if not mapping:
-        raise Exception("No network drive mappings given")
     if mapping[sys.platform] in str_or_path:
         # return if path is already for the current OS
+        return str_or_path
+    if os.path.exists(str_or_path):
         return str_or_path
     mp = get_mount_point_len(mapping, str_or_path)
     if mp == 0:

--- a/adapter/comm/tools.py
+++ b/adapter/comm/tools.py
@@ -57,12 +57,10 @@ def convert_network_drive_path(str_or_path, mapping={'win32': 'X:', 'darwin': '/
     if mapping[sys.platform] in str_or_path:
         # return if path is already for the current OS
         return str_or_path
-    mp = 0
-    for v in mapping.values():
-        if v in str_or_path:
-            mp = len(v)
+    mp = get_mount_point_len(mapping, str_or_path)
     if mp == 0:
-        raise IOError("the given path doesn't match any of OS mappings")
+        raise IOError(f"the given path: {str_or_path} doesn't match any of OS mappings! If you work with a local dir, "
+                      f"set isLocal arg as IO(isLocal=True) or i_o.write(isLocal=True)")
     if ':' in str_or_path:
         file_path = PureWindowsPath(str_or_path[mp + 1:])
     else:
@@ -74,6 +72,27 @@ def convert_network_drive_path(str_or_path, mapping={'win32': 'X:', 'darwin': '/
         return str(PurePosixPath(mapping[sys.platform]).joinpath(file_path))
     else:
         raise IOError(f'Not supported OS: {sys.platform}!')
+
+
+def get_mount_point_len(mapping: dict, str_or_path: str) -> int:
+    """Get the length of the current mount point. For example, get_mount_point_len(mapping= {'win32': 'X:',
+    'darwin': '/Volumes/A', 'linux': '/media/b'}, str_or_path=r'X:\xyz\uvw.py')=> 2
+
+    Args:
+        mapping: dict
+            A OS and mount_point pair. For example, {'win32': 'X:', 'darwin': '/Volumes/A', 'linux': '/media/b'}
+        str_or_path: str
+            A path str. For example, r'C:\Abc\1.txt'
+
+    Returns:
+        the length of the mount point
+
+    """
+    mp = 0
+    for v in mapping.values():
+        if v.upper() == (str_or_path[:len(v)]).upper():
+            return len(v)
+    return mp
 
 
 def user_select_file(user_message="", mul_fls=False):

--- a/adapter/comm/tools.py
+++ b/adapter/comm/tools.py
@@ -57,14 +57,20 @@ def convert_network_drive_path(str_or_path, mapping={'win32': 'X:', 'darwin': '/
     if mapping[sys.platform] in str_or_path:
         # return if path is already for the current OS
         return str_or_path
-    pp = PurePath(str_or_path)
-    file_path = '/'.join(pp.parts[1:])
+    mp = 0
+    for v in mapping.values():
+        if v in str_or_path:
+            mp = len(v)
+    if mp == 0:
+        raise IOError("the given path doesn't match any of OS mappings")
+    if ':' in str_or_path:
+        file_path = PureWindowsPath(str_or_path[mp + 1:])
+    else:
+        file_path = PurePosixPath(str_or_path[mp + 1:])
     if sys.platform == 'win32':
         # convert to current system's mount point when mount point and sys not the same
         return str(PureWindowsPath(mapping[sys.platform]).joinpath(file_path))
-    elif sys.platform == 'darwin':
-        return str(PurePosixPath(mapping[sys.platform]).joinpath(file_path))
-    elif sys.platform == 'linux':
+    elif sys.platform == 'darwin' or sys.platform == 'linux':
         return str(PurePosixPath(mapping[sys.platform]).joinpath(file_path))
     else:
         raise IOError(f'Not supported OS: {sys.platform}!')

--- a/adapter/comm/tools.py
+++ b/adapter/comm/tools.py
@@ -25,7 +25,10 @@ def process_column_labels(list_of_labels):
     return list_of_cleaned_labels
 
 
-def convert_network_drive_path(str_or_path, mapping={'win32': 'X:', 'darwin': '/Volumes/A', 'linux': '/media/b'}):
+def convert_network_drive_path(
+    str_or_path,
+    mapping={"win32": "X:", "darwin": "/Volumes/A", "linux": "/media/b"},
+):
     """
     Convert network drive paths from those formatted for one OS into those formatted for another. (works for Windows,
     OSX, Linux)
@@ -46,9 +49,11 @@ def convert_network_drive_path(str_or_path, mapping={'win32': 'X:', 'darwin': '/
     Raises:
         Exception: When no mapping is given or running on an unsupported OS
     """
-    if (not isinstance(str_or_path, str)) \
-            or os.path.isfile(str_or_path) \
-            or (not (str_or_path[0] == '/' or ':' in str_or_path)):
+    if (
+        (not isinstance(str_or_path, str))
+        or os.path.isfile(str_or_path)
+        or (not (str_or_path[0] == "/" or ":" in str_or_path))
+    ):
         # return if abs file exists or path is absolute, return if it's relative.
         # Note: either os.path nor pathlib work correctly
         return str_or_path
@@ -59,38 +64,38 @@ def convert_network_drive_path(str_or_path, mapping={'win32': 'X:', 'darwin': '/
         return str_or_path
     mp = get_mount_point_len(mapping, str_or_path)
     if mp == 0:
-        raise IOError(f"the given path: {str_or_path} doesn't match any of OS mappings! If you work with a local dir, "
-                      f"set isLocal arg as IO(isLocal=True) or i_o.write(isLocal=True)")
-    if ':' in str_or_path:
-        file_path = PureWindowsPath(str_or_path[mp + 1:])
+        raise IOError(
+            f"the given path: {str_or_path} doesn't match any of OS mappings! If you work with a local dir, "
+            f"set isLocal arg as IO(isLocal=True) or i_o.write(isLocal=True)"
+        )
+    if ":" in str_or_path:
+        file_path = PureWindowsPath(str_or_path[mp + 1 :])
     else:
-        file_path = PurePosixPath(str_or_path[mp + 1:])
-    if sys.platform == 'win32':
+        file_path = PurePosixPath(str_or_path[mp + 1 :])
+    if sys.platform == "win32":
         # convert to current system's mount point when mount point and sys not the same
         return str(PureWindowsPath(mapping[sys.platform]).joinpath(file_path))
-    elif sys.platform == 'darwin' or sys.platform == 'linux':
+    elif sys.platform == "darwin" or sys.platform == "linux":
         return str(PurePosixPath(mapping[sys.platform]).joinpath(file_path))
     else:
-        raise IOError(f'Not supported OS: {sys.platform}!')
+        raise IOError(f"Not supported OS: {sys.platform}!")
 
 
 def get_mount_point_len(mapping: dict, str_or_path: str) -> int:
-    """Get the length of the current mount point. For example, get_mount_point_len(mapping= {'win32': 'X:',
-    'darwin': '/Volumes/A', 'linux': '/media/b'}, str_or_path=r'X:\xyz\uvw.py')=> 2
+    """Get the length of the current mount point.
 
-    Args:
+    Parameters:
         mapping: dict
             A OS and mount_point pair. For example, {'win32': 'X:', 'darwin': '/Volumes/A', 'linux': '/media/b'}
         str_or_path: str
-            A path str. For example, r'C:\Abc\1.txt'
+            A path str. For example, 'X:\Abc\1.txt'
 
     Returns:
-        the length of the mount point
-
+            the length of the mount point
     """
     mp = 0
     for v in mapping.values():
-        if v.upper() == (str_or_path[:len(v)]).upper():
+        if v.upper() == (str_or_path[: len(v)]).upper():
             return len(v)
     return mp
 
@@ -154,7 +159,8 @@ def user_select_file(user_message="", mul_fls=False):
 
         else:
             fpath = fd.askopenfilename(
-                title=user_message, filetypes=[("Excel", "*.xlsx *.xls"), ("Database", "*.db")]
+                title=user_message,
+                filetypes=[("Excel", "*.xlsx *.xls"), ("Database", "*.db")],
             )
 
         return fpath

--- a/adapter/comm/tools.py
+++ b/adapter/comm/tools.py
@@ -1,3 +1,4 @@
+import os
 import re
 import sys
 from pathlib import PurePath, PureWindowsPath, PurePosixPath
@@ -45,11 +46,10 @@ def convert_network_drive_path(str_or_path, mapping={'win32': 'X:', 'darwin': '/
     Raises:
         Exception: When no mapping is given or running on an unsupported OS
     """
-    if not isinstance(str_or_path, str):
-        return str_or_path
-    pp = PurePath(str_or_path)
-    if not (str_or_path[0] == '/' or ':' in str_or_path):
-        # check path is absolute, return if it's relative.
+    if (not isinstance(str_or_path, str)) \
+            or os.path.isfile(str_or_path) \
+            or (not (str_or_path[0] == '/' or ':' in str_or_path)):
+        # return if abs file exists or path is absolute, return if it's relative.
         # Note: either os.path nor pathlib work correctly
         return str_or_path
     if not mapping:
@@ -57,6 +57,7 @@ def convert_network_drive_path(str_or_path, mapping={'win32': 'X:', 'darwin': '/
     if mapping[sys.platform] in str_or_path:
         # return if path is already for the current OS
         return str_or_path
+    pp = PurePath(str_or_path)
     file_path = '/'.join(pp.parts[1:])
     if sys.platform == 'win32':
         # convert to current system's mount point when mount point and sys not the same

--- a/adapter/comm/tools.py
+++ b/adapter/comm/tools.py
@@ -26,8 +26,8 @@ def process_column_labels(list_of_labels):
 
 
 def convert_network_drive_path(
-        str_or_path,
-        mapping={"win32": "X:", "darwin": "/Volumes/A", "linux": "/media/b"},
+    str_or_path,
+    mapping={"win32": "X:", "darwin": "/Volumes/A", "linux": "/media/b"},
 ):
     """
     Convert network drive paths from those formatted for one OS into those formatted for another. (works for Windows,
@@ -53,8 +53,8 @@ def convert_network_drive_path(
     if not isinstance(mapping, dict):
         # automatically assume list of tuples
         os_mapping = {
-            'win32': mapping[0][0],
-            'darwin': mapping[0][1],
+            "win32": mapping[0][0],
+            "darwin": mapping[0][1],
         }
         mapping = os_mapping
     if not isinstance(str_or_path, str):
@@ -73,9 +73,11 @@ def convert_network_drive_path(
         return str_or_path
     if ":" in str_or_path:
         # create win path
-        file_path = PureWindowsPath(str_or_path[str_or_path.index(':') + 2:])
+        file_path = PureWindowsPath(str_or_path[str_or_path.index(":") + 2 :])
     else:
-        file_path = PurePosixPath(str_or_path[get_mount_point_len(mapping, str_or_path) + 1:])
+        file_path = PurePosixPath(
+            str_or_path[get_mount_point_len(mapping, str_or_path) + 1 :]
+        )
     if sys.platform == "win32":
         # convert to current system's mount point when mount point and sys not the same
         return str(PureWindowsPath(mapping[sys.platform]).joinpath(file_path))

--- a/adapter/comm/tools.py
+++ b/adapter/comm/tools.py
@@ -26,8 +26,8 @@ def process_column_labels(list_of_labels):
 
 
 def convert_network_drive_path(
-    str_or_path,
-    mapping={"win32": "X:", "darwin": "/Volumes/A", "linux": "/media/b"},
+        str_or_path,
+        mapping={"win32": "X:", "darwin": "/Volumes/A", "linux": "/media/b"},
 ):
     """
     Convert network drive paths from those formatted for one OS into those formatted for another. (works for Windows,
@@ -53,8 +53,8 @@ def convert_network_drive_path(
     if not isinstance(mapping, dict):
         # automatically assume list of tuples
         os_mapping = {
-            'win32': mapping[0],
-            'darwin': mapping[1],
+            'win32': mapping[0][0],
+            'darwin': mapping[0][1],
         }
         mapping = os_mapping
     if not isinstance(str_or_path, str):
@@ -68,16 +68,14 @@ def convert_network_drive_path(
         return str_or_path
     if os.path.exists(str_or_path):
         return str_or_path
-    mp = get_mount_point_len(mapping, str_or_path)
-    if mp == 0:
-        raise IOError(
-            f"the given path: {str_or_path} doesn't match any of OS mappings! If you work with a local dir, "
-            f"set isLocal arg as IO(isLocal=True) or i_o.write(isLocal=True)"
-        )
+    if os.getcwd() in str_or_path:
+        # return if it's a local relative path
+        return str_or_path
     if ":" in str_or_path:
-        file_path = PureWindowsPath(str_or_path[mp + 1 :])
+        # create win path
+        file_path = PureWindowsPath(str_or_path[get_mount_point_len(mapping, str_or_path) + 1:])
     else:
-        file_path = PurePosixPath(str_or_path[mp + 1 :])
+        file_path = PurePosixPath(str_or_path[get_mount_point_len(mapping, str_or_path) + 1:])
     if sys.platform == "win32":
         # convert to current system's mount point when mount point and sys not the same
         return str(PureWindowsPath(mapping[sys.platform]).joinpath(file_path))

--- a/adapter/comm/tools.py
+++ b/adapter/comm/tools.py
@@ -73,7 +73,7 @@ def convert_network_drive_path(
         return str_or_path
     if ":" in str_or_path:
         # create win path
-        file_path = PureWindowsPath(str_or_path[str_or_path.index(':') + 1:])
+        file_path = PureWindowsPath(str_or_path[str_or_path.index(':') + 2:])
     else:
         file_path = PurePosixPath(str_or_path[get_mount_point_len(mapping, str_or_path) + 1:])
     if sys.platform == "win32":

--- a/adapter/i_o.py
+++ b/adapter/i_o.py
@@ -58,11 +58,17 @@ class IO(object):
     """
 
     def __init__(self, path, os_mapping={'win32': 'X:', 'darwin': '/Volumes/A',
-                                         'linux': '/media/b'}, isLocal=False):
-
-        self.os_mapping = os_mapping
-        if not isLocal:
-            path = convert_network_drive_path(path, mapping=os_mapping)
+                                         'linux': '/media/b'}):
+        # backwards compatibility
+        if not isinstance(os_mapping, dict):
+            # automatically assume list of tuples
+            self.os_mapping = {
+                'win32': os_mapping[0],
+                'darwin': os_mapping[1]
+            }
+        else:
+            self.os_mapping = os_mapping
+        path = convert_network_drive_path(path, mapping=os_mapping)
 
         self.input_path = path
 

--- a/adapter/i_o.py
+++ b/adapter/i_o.py
@@ -56,8 +56,8 @@ class IO(object):
             Defaults to [("X:","/Volumes/my_folder")].
 
     """
-
-    def __init__(self, path, os_mapping=[("X:", "/Volumes/my_drive")]):
+    def __init__(self, path, os_mapping={'win32': 'X:', 'darwin': '/Volumes/A',
+                                         'linux': '/media/b'}):
 
         self.os_mapping = os_mapping
 

--- a/adapter/i_o.py
+++ b/adapter/i_o.py
@@ -63,8 +63,8 @@ class IO(object):
         if not isinstance(os_mapping, dict):
             # automatically assume list of tuples
             self.os_mapping = {
-                'win32': os_mapping[0],
-                'darwin': os_mapping[1]
+                'win32': os_mapping[0][0],
+                'darwin': os_mapping[0][1]
             }
         else:
             self.os_mapping = os_mapping
@@ -615,7 +615,6 @@ class IO(object):
             run_tag="",
             db_conn=None,
             close_db=True,
-            isLocal=False
     ):
         """Writes all dataframes from a dictionary of dataframes
         out into an existing database.
@@ -702,8 +701,7 @@ class IO(object):
         else:
             if outpath is None:
                 outpath = os.getcwd()
-        if not isLocal:
-            outpath = convert_network_drive_path(outpath, mapping=self.os_mapping)
+        outpath = convert_network_drive_path(outpath, mapping=self.os_mapping)
 
         if data_as_dict_of_dfs is None:
             msg = "No data to write passed."

--- a/adapter/i_o.py
+++ b/adapter/i_o.py
@@ -56,12 +56,13 @@ class IO(object):
             Defaults to [("X:","/Volumes/my_folder")].
 
     """
+
     def __init__(self, path, os_mapping={'win32': 'X:', 'darwin': '/Volumes/A',
-                                         'linux': '/media/b'}):
+                                         'linux': '/media/b'}, isLocal=False):
 
         self.os_mapping = os_mapping
-
-        path = convert_network_drive_path(path, mapping=os_mapping)
+        if not isLocal:
+            path = convert_network_drive_path(path, mapping=os_mapping)
 
         self.input_path = path
 
@@ -600,14 +601,15 @@ class IO(object):
         return res
 
     def write(
-        self,
-        type="db",
-        data_connection=None,
-        data_as_dict_of_dfs=None,
-        outpath=None,
-        run_tag="",
-        db_conn=None,
-        close_db=True,
+            self,
+            type="db",
+            data_connection=None,
+            data_as_dict_of_dfs=None,
+            outpath=None,
+            run_tag="",
+            db_conn=None,
+            close_db=True,
+            isLocal=False
     ):
         """Writes all dataframes from a dictionary of dataframes
         out into an existing database.
@@ -694,8 +696,8 @@ class IO(object):
         else:
             if outpath is None:
                 outpath = os.getcwd()
-
-        outpath = convert_network_drive_path(outpath, mapping=self.os_mapping)
+        if not isLocal:
+            outpath = convert_network_drive_path(outpath, mapping=self.os_mapping)
 
         if data_as_dict_of_dfs is None:
             msg = "No data to write passed."


### PR DESCRIPTION
After carefully investigating convert_network_drive_path's behavior, I changed mapping from a list of tuples to a dict to minimize impact to its callers/users and add the ability to run on Linux.

Impacts: convert_network_drive_path() is used by IO constructor

An input path str can convert to a path format according to its OS.
Examples,
`convert_network_drive_path(str_or_path=r'C:\my_dir\my_file.txt', mapping={'win32': 'X:', 'darwin': '/Volumes/A', 'linux': '/media/b'})`
on Mac
`=>'/Volumes/A/my_dir/my_file.txt'`
on Linux, 
`=>'/media/b/my_dir/my_file.txt'`
on Windows, 
`=>'X:\my_dir\my_file.txt'`

`convert_network_drive_path(str_or_path='//Volumes/A/my_dir/my_file.txt', mapping={'win32': 'X:', 'darwin': '/Volumes/A', 'linux': '/media/b'})`
on Mac
`=>'/Volumes/A/my_dir/my_file.txt'`
on Linux, 
`=>'/media/b/my_dir/my_file.txt'`
on Windows, 
`=>'X:\my_dir\my_file.txt'`

output remains the same as input when the input path is a relative path
`convert_network_drive_path(str_or_path='my_dir\my_file.txt', mapping={'win32': 'X:', 'darwin': '/Volumes/A', 'linux': '/media/b'})`
on Mac
`=>'my_dir\my_file.txt'`
on Linux, 
`=>'my_dir\my_file.txt'`
on Windows, 
`=>'my_dir\my_file.txt'`