### PR TITLE
quick fix for openpyxl and SQLAlchemy backwards compatibility issue

### DIFF
--- a/adapter/__init__.py
+++ b/adapter/__init__.py
@@ -5,4 +5,4 @@
 
 # build dist backup: drive, Public Code/Adapter
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "pandas>=1.0.4",
         "xlwings>=0.19.4",
         "psycopg2-binary>=2.8.6",
-        "SQLAlchemy>=1.4.28",
-        "openpyxl>=3.0.9",
+        "SQLAlchemy<=1.4.29",
+        "openpyxl<=3.0.9",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "pandas>=1.0.4",
         "xlwings>=0.19.4",
         "psycopg2-binary>=2.8.6",
-        "SQLAlchemy<=1.4.29",
-        "openpyxl<=3.0.9",
+        "SQLAlchemy==1.4.29",
+        "openpyxl==3.0.9",
     ],
 )


### PR DESCRIPTION
I created a patch solution by specifying the dependency versions; All unit tests passed.
 `"SQLAlchemy==1.4.29", "openpyxl==3.0.9"`