### PR TITLE
44 45 dependency update

### DIFF
--- a/adapter/__init__.py
+++ b/adapter/__init__.py
@@ -5,5 +5,5 @@
 
 # build dist backup: drive, Public Code/Adapter
 
-__version__ = "1.6.1"
+__version__ = "1.7.0"
 

--- a/adapter/to_python.py
+++ b/adapter/to_python.py
@@ -73,14 +73,7 @@ class Excel(object):
                 the corresponding named data object
                 values
         """
-        # check if any name in data_object_names not in excel file
-        if hasattr(self.wb.defined_names,"definedName"):
-            # This case is for openpyxl <3.1.0
-            all_input_ranges = {object_range.name for object_range in self.wb.defined_names.definedName}
-        else:
-            # This case is for openpyxl ≥3.1.0
-            all_input_ranges = set(self.wb.defined_names.keys())
-            
+        all_input_ranges = set(self.wb.defined_names.keys())    
         all_input_tables = {object_table for ws in self.wb.worksheets for object_table in ws.tables.keys()}
         all_input_objects = all_input_ranges | all_input_tables
 

--- a/adapter/to_python.py
+++ b/adapter/to_python.py
@@ -74,7 +74,13 @@ class Excel(object):
                 values
         """
         # check if any name in data_object_names not in excel file
-        all_input_ranges = {object_range.name for object_range in self.wb.defined_names.definedName}
+        if hasattr(self.wb.defined_names,"definedName"):
+            # This case is for openpyxl <3.1.0
+            all_input_ranges = {object_range.name for object_range in self.wb.defined_names.definedName}
+        else:
+            # This case is for openpyxl ≥3.1.0
+            all_input_ranges = set(self.wb.defined_names.keys())
+            
         all_input_tables = {object_table for ws in self.wb.worksheets for object_table in ws.tables.keys()}
         all_input_objects = all_input_ranges | all_input_tables
 

--- a/adapter/to_python.py
+++ b/adapter/to_python.py
@@ -73,6 +73,7 @@ class Excel(object):
                 the corresponding named data object
                 values
         """
+        # check if any name in data_object_names not in excel file
         all_input_ranges = set(self.wb.defined_names.keys())    
         all_input_tables = {object_table for ws in self.wb.worksheets for object_table in ws.tables.keys()}
         all_input_objects = all_input_ranges | all_input_tables

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,6 @@ setup(
         "xlwings>=0.19.4",
         "psycopg2-binary>=2.8.6",
         "SQLAlchemy>=2.0.0",
-        "openpyxl>=3.0.9",
+        "openpyxl>=3.1.2",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,10 @@ setup(
     keywords="data, tables, IO for research computation, sql, excel, csv, dataframe, connection",
     packages=find_packages(exclude=["*.tests", "*.tests"]),
     install_requires=[
-        "pandas>=1.0.4",
+        "pandas>=2.2.0",
         "xlwings>=0.19.4",
         "psycopg2-binary>=2.8.6",
-        "SQLAlchemy==1.4.29",
-        "openpyxl==3.0.9",
+        "SQLAlchemy>=2.0.0",
+        "openpyxl>=3.0.9",
     ],
 )


### PR DESCRIPTION
This is a minor version increment to:

- Update to `pandas≥2.2.0` dependency
- Update to `sqlalchemy≥2.0.0` dependency, based on [minimum pandas2.2.0 requirement](https://pandas.pydata.org/pandas-docs/version/2.2/getting_started/install.html#sql-databases)
- Update to `openpyxl≥3.1.2` dependency, based on the [minimum pandas2.2.0 requirement](https://pandas.pydata.org/pandas-docs/version/2.2/getting_started/install.html#excel-files) that will allow `to_python` to work as written here

The idea is that this new version of adapter can be used to test `pandas≥2.2.0` compatibility updates to our tools, which can "jump" to this newer version after having updated relevant code to accommodate `pandas≥2.2.0`.

I tested this in a brand new environment by just installing dependencies as listed here and the tests still pass. I did have to deal with a tkinter issue (resolved [here](https://stackoverflow.com/questions/76105218/why-does-tkinter-or-turtle-seem-to-be-missing-or-broken-shouldnt-it-be-part), completely outside of python dependencies controllable in this repo)

This PR would take precedence over [this one](https://github.com/LBNL-ETA/Adapter/pull/41) from last year, just because it's updating all the dependencies together